### PR TITLE
feat: Support high-performance ImmutableArray builder filling

### DIFF
--- a/.idea/.idea.RaiqubToolkit/.idea/vcs.xml
+++ b/.idea/.idea.RaiqubToolkit/.idea/vcs.xml
@@ -3,8 +3,6 @@
   <component name="CommitMessageInspectionProfile">
     <profile version="1.0">
       <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
       <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
     </profile>
   </component>

--- a/src/Core/InteropServices/ImmutableCollectionsMarshal.cs
+++ b/src/Core/InteropServices/ImmutableCollectionsMarshal.cs
@@ -1,0 +1,101 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+
+namespace Raiqub.Toolkit.Core.InteropServices;
+
+/// <summary>
+/// An unsafe class that provides a set of methods to access the underlying data representations of immutable collections.
+/// </summary>
+public static class ImmutableCollectionsMarshal
+{
+    /// <summary>
+    /// Gets an <see cref="ImmutableArray{T}"/> value wrapping the input <typeparamref name="T"/> array.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the input array.</typeparam>
+    /// <param name="array">The input array to wrap in the returned <see cref="ImmutableArray{T}"/> value.</param>
+    /// <returns>An <see cref="ImmutableArray{T}"/> value wrapping <paramref name="array"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// When using this method, callers should take extra care to ensure that they're the sole owners of the input
+    /// array, and that it won't be modified once the returned <see cref="ImmutableArray{T}"/> value starts being
+    /// used. Doing so might cause undefined behavior in code paths which don't expect the contents of a given
+    /// <see cref="ImmutableArray{T}"/> values to change after its creation.
+    /// </para>
+    /// <para>
+    /// If <paramref name="array"/> is <see langword="null"/>, the returned <see cref="ImmutableArray{T}"/> value
+    /// will be uninitialized (ie. its <see cref="ImmutableArray{T}.IsDefault"/> property will be <see langword="true"/>).
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ImmutableArray<T> AsImmutableArray<T>(T[]? array)
+    {
+        return System.Runtime.InteropServices.ImmutableCollectionsMarshal.AsImmutableArray(array);
+    }
+
+    /// <summary>
+    /// Gets the underlying <typeparamref name="T"/> array for an input <see cref="ImmutableArray{T}"/> value.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the input <see cref="ImmutableArray{T}"/> value.</typeparam>
+    /// <param name="array">The input <see cref="ImmutableArray{T}"/> value to get the underlying <typeparamref name="T"/> array from.</param>
+    /// <returns>The underlying <typeparamref name="T"/> array for <paramref name="array"/>, if present.</returns>
+    /// <remarks>
+    /// <para>
+    /// When using this method, callers should make sure to not pass the resulting underlying array to methods that
+    /// might mutate it. Doing so might cause undefined behavior in code paths using <paramref name="array"/> which
+    /// don't expect the contents of the <see cref="ImmutableArray{T}"/> value to change.
+    /// </para>
+    /// <para>
+    /// If <paramref name="array"/> is uninitialized (ie. its <see cref="ImmutableArray{T}.IsDefault"/> property is
+    /// <see langword="true"/>), the resulting <typeparamref name="T"/> array will be <see langword="null"/>.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T[]? AsArray<T>(ImmutableArray<T> array)
+    {
+        return System.Runtime.InteropServices.ImmutableCollectionsMarshal.AsArray(array);
+    }
+
+    /// <summary>
+    /// Get a <see cref="Span{T}"/> view over a <see cref="ImmutableArray{T}.Builder"/>'s data.
+    /// Items should not be added or removed from the <see cref="ImmutableArray{T}.Builder"/> while the <see cref="Span{T}"/> is in use.
+    /// </summary>
+    /// <param name="builder">The immutable array builder to get the data view over.</param>
+    /// <typeparam name="T">The type of the elements in the builder.</typeparam>
+    public static Span<T> AsSpan<T>(ImmutableArray<T>.Builder? builder)
+    {
+        if (builder is null)
+        {
+            return default;
+        }
+
+        var accessor = Unsafe.As<ImmutableArray<T>.Builder, ImmutableArrayBuilderAccessor<T>>(ref builder);
+        return new Span<T>(accessor.Elements, 0, accessor.Count);
+    }
+
+    /// <summary>
+    /// Sets the count of the <see cref="ImmutableArray{T}.Builder"/> to the specified value.
+    /// </summary>
+    /// <param name="builder">The immutable array builder to set the count of.</param>
+    /// <param name="count">The value to set the builder's count to.</param>
+    /// <typeparam name="T">The type of the elements in the builder.</typeparam>
+    /// <exception cref="NullReferenceException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is negative.</exception>
+    /// <remarks>When increasing the count, uninitialized data is being exposed.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void SetCount<T>(ImmutableArray<T>.Builder builder, int count)
+    {
+        builder.Count = count;
+    }
+
+    private sealed class ImmutableArrayBuilderAccessor<T>
+    {
+        public T[] Elements;
+        public int Count;
+
+        public ImmutableArrayBuilderAccessor(T[] elements, int count)
+        {
+            Elements = elements;
+            Count = count;
+        }
+    }
+}

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -13,6 +13,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Core.Tests/InteropServices/ImmutableCollectionsMarshalTest.cs
+++ b/tests/Core.Tests/InteropServices/ImmutableCollectionsMarshalTest.cs
@@ -1,0 +1,118 @@
+using System.Collections.Immutable;
+using FluentAssertions;
+using Raiqub.Toolkit.Core.InteropServices;
+
+namespace Raiqub.Toolkit.Core.Tests.InteropServices;
+
+public class ImmutableCollectionsMarshalTest
+{
+    [Fact]
+    public void AsImmutableArrayShouldWrapInputArrayWhenInputIsNotNull()
+    {
+        // Arrange
+        int[] array = [1, 2, 3];
+
+        // Act
+        var immutableArray = ImmutableCollectionsMarshal.AsImmutableArray(array);
+
+        // Assert
+        immutableArray.IsDefault.Should().BeFalse();
+        immutableArray.Should().HaveCount(array.Length);
+        immutableArray.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void AsArrayShouldReturnUnderlyingArrayWhenInputIsInitialized()
+    {
+        // Arrange
+        var array = ImmutableArray.Create([1, 2, 3]);
+
+        // Act
+        var resultArray = ImmutableCollectionsMarshal.AsArray(array);
+
+        // Assert
+        Assert.NotNull(resultArray);
+        resultArray.Should().HaveCount(array.Length);
+        resultArray.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void AsSpanShouldReturnEmptySpanWhenBuilderIsNull()
+    {
+        // Arrange
+        ImmutableArray<int>.Builder? builder = null;
+
+        // Act
+        var span = ImmutableCollectionsMarshal.AsSpan(builder);
+
+        // Assert
+        span.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AsSpanShouldReturnSpanViewWithCorrectLengthAndData()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<int>();
+        builder.Add(10);
+        builder.Add(20);
+        builder.Add(30);
+
+        // Act
+        var span = ImmutableCollectionsMarshal.AsSpan(builder);
+
+        // Assert
+        span.Length.Should().Be(builder.Count);
+        span[0].Should().Be(builder[0]);
+        span[1].Should().Be(builder[1]);
+        span[2].Should().Be(builder[2]);
+    }
+
+    [Fact]
+    public void AsSpanShouldReturnSpanViewWithCorrectDataAfterAddingItems()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<int>();
+        builder.Add(100);
+
+        // Act
+        var span = ImmutableCollectionsMarshal.AsSpan(builder);
+        builder.Add(200); // Add more items after creating the span
+
+        // Assert
+        span[0].Should().Be(100); // Ensure span still reflects initial state
+    }
+
+    [Fact]
+    public void AsSpanShouldReturnSpanThatWritesDirectlyToBuilder()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<int>();
+
+        // Act
+        builder.Count = 3;
+        var span = ImmutableCollectionsMarshal.AsSpan(builder);
+        span[0] = 100;
+        span[1] = 123;
+        span[2] = 349;
+
+        // Assert
+        builder.Should().Equal(100, 123, 349);
+    }
+
+    [Fact]
+    public void SetCountShouldResizeToSpecifiedCapacity()
+    {
+        var builder = ImmutableArray.CreateBuilder<int>(0);
+
+        ImmutableCollectionsMarshal.SetCount(builder, 5);
+        var span = ImmutableCollectionsMarshal.AsSpan(builder);
+        span[0] = 100;
+        span[1] = 123;
+        span[2] = 349;
+        span[3] = 483;
+        span[4] = 550;
+
+        builder.Should().Equal(100, 123, 349, 483, 550);
+    }
+}

--- a/tests/Core.Tests/packages.lock.json
+++ b/tests/Core.Tests/packages.lock.json
@@ -14,6 +14,15 @@
         "resolved": "6.0.2",
         "contentHash": "8b4jBNH7mcQy1otyQErjjIUuGD74XxKZ1wvDufbY7jhWwckl7wIa+icjwdPYeI0aYMS4Tp63LIZvyMFjWwOMDw=="
       },
+      "FluentAssertions": {
+        "type": "Direct",
+        "requested": "[6.12.2, )",
+        "resolved": "6.12.2",
+        "contentHash": "8YE+xJmT8wgzEpFuzJ4S62oFhEL/AKouMz1RWPEMEUhy9H11aRQlGIWcHurH5BEy7tbF6gb0CJrs0wOw/AtDcQ==",
+        "dependencies": {
+          "System.Configuration.ConfigurationManager": "4.4.0"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.12.0, )",
@@ -68,10 +77,23 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gWwQv/Ug1qWJmHCmN17nAbxJYmQBM/E94QxKLksvUiiKB1Ld3Sc/eK1lgmbSjDFxkQhVuayI/cGFZhpBSodLrg==",
+        "dependencies": {
+          "System.Security.Cryptography.ProtectedData": "4.4.0"
+        }
+      },
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "1.6.0",
         "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "cJV7ScGW7EhatRsjehfvvYVBvtiSMKgN8bOVI0bQhnF5bU7vnHVIsH49Kva7i7GWaWYvmEzkYVk1TC+gZYBEog=="
       },
       "xunit.abstractions": {
         "type": "Transitive",


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Toolkit!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Fix #41

## Details on the issue fix or feature implementation
- Create ImmutableCollectionsMarshal with `AsSpan` method supporting to extract an `Span` from `ImmutableArray` builder

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
